### PR TITLE
Fix prompt loading fallback when no path provided

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -94,9 +94,19 @@ export function loadReadme(readmePath?: string): string {
   }
 }
 
-export function loadPrompt(promptPath: string): string {
+export function loadPrompt(promptPath?: string): string {
+  const loadBundledPrompt = () => {
+    const bundledPath = path.join(__dirname, 'AutoTriage.prompt');
+    return fs.readFileSync(bundledPath, 'utf8');
+  };
+
   if (!promptPath) {
-    throw new Error('Prompt path is required');
+    try {
+      return loadBundledPrompt();
+    } catch (bundledError) {
+      const bundledMessage = getErrorMessage(bundledError);
+      throw new Error(`Failed to load prompt. Bundled fallback: ${bundledMessage}`);
+    }
   }
 
   try {
@@ -108,8 +118,7 @@ export function loadPrompt(promptPath: string): string {
   } catch (error) {
     // Fall back to bundled default prompt
     try {
-      const bundledPath = path.join(__dirname, 'AutoTriage.prompt');
-      return fs.readFileSync(bundledPath, 'utf8');
+      return loadBundledPrompt();
     } catch (bundledError) {
       const customMessage = getErrorMessage(error);
       const bundledMessage = getErrorMessage(bundledError);


### PR DESCRIPTION
## Summary
- allow the storage loader to use the bundled prompt when no custom path is supplied
- surface clearer error messaging when bundled prompt loading fails

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e9f8eb544483289519af093cf1d24d