### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/danielchalmers/AutoTriage/security/code-scanning/1](https://github.com/danielchalmers/AutoTriage/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/tests.yml` so the workflow does not inherit potentially broad defaults.  
Best fix without changing functionality: define workflow-level permissions right after the `on` block (before `jobs`) with `contents: read`. This is sufficient for `actions/checkout` and the listed test steps, and applies uniformly to all jobs unless overridden later.

Change location:
- File: `.github/workflows/tests.yml`
- Insert:
  - `permissions:`
  - `  contents: read`
- Place between the trigger section and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
