### PR TITLE
Tighten project guidance and public docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,261 +1,68 @@
 # AGENTS.md
 
-This document provides comprehensive instructions for AI agents and developers working on the AutoTriage project. It outlines the setup process, development workflow, testing procedures, and build requirements.
+Guidance for agents working in this repository.
 
-## Project Overview
+## Project
 
-AutoTriage is a GitHub Action that uses AI to automatically triage issues and pull requests. It's built with TypeScript and requires Node.js 24+ for development, and runs on Node.js 24 in GitHub Actions.
+AutoTriage is a Node 24 GitHub Action written in TypeScript. Source lives in `src/`, tests live in `tests/`, and the action entrypoint is the generated `dist/index.js`.
 
-## Prerequisites
+## Ground Rules
 
-- **Node.js**: Version 24 or higher (specified in `package.json` engines)
-- **npm**: Comes bundled with Node.js
-- **Git**: For version control
-- **GitHub Token**: Required for testing (set as `GITHUB_TOKEN` environment variable)
-- **Gemini API Key**: Required for AI functionality when running the action locally (set as `GEMINI_API_KEY` environment variable)
+- Never edit `dist/` by hand. Regenerate it with `npm run build`.
+- Keep changes scoped to the request. Avoid drive-by refactors, formatting churn, and unrelated dependency updates.
+- Prefer existing patterns and local helpers over new abstractions.
+- Use ASCII unless the touched file already uses non-ASCII or the content requires it.
 
-## Repository Structure
+## Commands
 
-```
-AutoTriage/
-├── .github/          # GitHub workflows and configuration
-├── dist/             # Compiled output (generated, committed to repo)
-├── examples/         # Example prompts and workflows
-├── src/              # TypeScript source code
-├── tests/            # Test files using Vitest
-├── action.yml        # GitHub Action metadata
-├── package.json      # Dependencies and scripts
-├── tsconfig.json     # TypeScript configuration
-└── vitest.config.ts  # Test configuration
-```
+- Install dependencies: `npm ci`
+- Type-check source: `npm run typecheck`
+- Type-check tests: `npm run typecheck:test`
+- Run tests: `npm test`
+- Build action bundle: `npm run build`
+- Watch TypeScript: `npm run dev`
 
-## Initial Setup
+Run the smallest useful verification first. For source changes that affect runtime behavior, run `npm run typecheck`, `npm test`, and `npm run build` when practical.
 
-### 1. Clone the Repository
+## Build And Dist
 
-```bash
-git clone https://github.com/danielchalmers/AutoTriage.git
-cd AutoTriage
-```
+`dist/` is committed because GitHub Actions executes `dist/index.js` directly. Any change to runtime source, bundled assets, dependencies, or action metadata may require `npm run build`.
 
-### 2. Install Dependencies
+CI checks that generated `dist/` output is current. If `npm run build` changes `dist/`, keep those generated changes with the source change unless the user asked for analysis only.
 
-```bash
-npm ci
-```
+## Behavior And Safety
 
-Use `npm ci` (clean install) for reproducible builds based on `package-lock.json`.
+`README.md` and `action.yml` describe the public action contract. Keep them aligned with behavior changes.
 
-### 3. Set Up Environment Variables
+AutoTriage may apply labels, comments, title changes, and issue state changes. Preserve default-deny authorization behavior unless the user explicitly asks to change it.
 
-Create a `.env` file in the root directory (this file is gitignored):
+Do not downgrade Node, `package.json` engines, or `action.yml` runtime without explicit request.
 
-```bash
-GITHUB_TOKEN=your_github_token_here
-GEMINI_API_KEY=your_gemini_api_key_here
-```
+## Tests
 
-These are required for local development when exercising the action against GitHub and Gemini. Unit tests do not require `GEMINI_API_KEY`.
+Tests use Vitest and should protect behavior, not just increase count.
 
-## Development Workflow
+Add or keep tests when they:
 
-### Available npm Scripts
+- Assert observable behavior, data shape, side effects, or error handling.
+- Cover a regression, boundary case, integration contract, or permission/safety rule.
+- Would fail for a realistic broken implementation.
 
-- `npm run typecheck` - Type-check TypeScript without emitting files
-- `npm run dev` - Watch mode for TypeScript compilation
-- `npm run build` - Full production build (includes typecheck, clean, compile, and asset copy)
-- `npm run clean` - Remove the dist directory
-- `npm run copy-assets` - Copy required assets to dist folder
-- `npm test` - Run all tests once
-- `npm run test:watch` - Run tests in watch mode
+Avoid or remove low-quality tests when they:
 
-### TypeScript Development
+- Only assert that a function "does not throw" without checking meaningful output.
+- Duplicate another test with different names but the same behavior.
+- Mirror implementation details so closely that refactors break tests without behavior changing.
+- Check trivial getters, setters, constants, or framework wiring unless those are part of a public contract.
+- Require broad mocks or fragile setup for little behavioral coverage.
 
-1. Make changes to source files in `src/`
-2. Run type checking: `npm run typecheck`
-3. For continuous development, use watch mode: `npm run dev`
+Prefer one focused test with strong assertions over several weak variations. When cleaning tests, preserve coverage for risky paths such as GitHub API calls, prompt construction, cache behavior, triage operation planning, database updates, and `dist` build expectations.
 
-### Testing
+## Runtime Inputs
 
-Tests are located in the `tests/` directory and use Vitest.
+Local action runs need:
 
-#### Running Tests
+- `GITHUB_TOKEN`
+- `GEMINI_API_KEY`
 
-```bash
-# Run all tests once
-npm test
-
-# Run tests in watch mode (for development)
-npm run test:watch
-```
-
-#### Test Environment
-
-- Tests use Vitest with Node.js environment
-- Setup file: `tests/setupEnv.ts`
-- Test files: `tests/**/*.test.ts`
-
-## Building the Project
-
-### Creating the dist Folder
-
-The `dist/` folder contains the compiled, bundled JavaScript that GitHub Actions executes. **This folder must be committed to the repository** as GitHub Actions runs directly from it.
-
-#### Build Process
-
-```bash
-npm run build
-```
-
-This command performs the following steps:
-
-1. **Type-checking** (`npm run typecheck`) - Validates TypeScript code
-2. **Clean** (`rimraf dist`) - Removes existing dist folder
-3. **Bundle** (`ncc build`) - Compiles and bundles TypeScript to a single JavaScript file
-   - Minifies the output
-   - Generates source maps
-   - Includes license information in `licenses.txt`
-4. **Copy Assets** (`npm run copy-assets`) - Copies `examples/AutoTriage.prompt` to dist as the bundled default prompt
-
-#### Important: Commit dist Changes
-
-After building, the `dist/` folder contents must be committed:
-
-```bash
-npm run build
-git add dist/
-git commit -m "Build: Update dist folder"
-```
-
-The CI workflow (`ci.yml`) verifies that the dist folder is up to date:
-
-```bash
-git status --porcelain
-git diff --exit-code --name-only
-```
-
-If you forget to rebuild dist after changing source code, the CI will fail.
-
-## Pre-commit Checklist
-
-Before committing changes, ensure:
-
-1. ✅ **Type-check passes**: `npm run typecheck`
-2. ✅ **Tests pass**: `npm test`
-3. ✅ **Build succeeds**: `npm run build`
-4. ✅ **dist is up to date**: Commit any changes in `dist/` folder
-5. ✅ **No uncommitted changes in dist**: `git status` shows clean dist
-
-## Continuous Integration
-
-The project uses GitHub Actions for CI (`.github/workflows/ci.yml`):
-
-1. Installs dependencies with `npm ci`
-2. Runs type-checking
-3. Builds the project
-4. Verifies dist folder is up to date
-5. Runs a mock triage test
-6. Runs unit tests (separate workflow: `tests.yml`)
-
-## Common Tasks
-
-### Adding New Dependencies
-
-```bash
-# Add production dependency
-npm install <package-name>
-
-# Add development dependency
-npm install -D <package-name>
-
-# Rebuild after adding dependencies
-npm run build
-```
-
-### Updating TypeScript Code
-
-1. Edit source files in `src/`
-2. Run `npm run typecheck` to verify types
-3. Run `npm test` to ensure tests pass
-4. Run `npm run build` to update dist
-5. Commit both source and dist changes
-
-### Debugging
-
-For debugging the action locally:
-
-1. Set up `.env` file with required tokens
-2. Use the mock triage setup from CI:
-   ```bash
-   # Build first
-   npm run build
-   
-   # Then test locally (requires proper GitHub Action environment)
-   ```
-
-### Working with the GitHub Action
-
-The action is defined in `action.yml` and runs from `dist/index.js`. Key points:
-
-- **Entry point**: `dist/index.js`
-- **Runtime**: Node.js 24 (specified in `action.yml`)
-- **Inputs**: Defined in `action.yml`
-- **Default prompt path**: `.github/AutoTriage.prompt` (where users place their custom prompt)
-- **Bundled prompt**: `examples/AutoTriage.prompt` (copied to dist during build as fallback)
-
-## File Artifacts
-
-The action generates artifacts during execution:
-
-- `triage-db.json` - Stores per-item history between runs
-- `artifacts/` - Contains thought processes and action logs
-
-These are gitignored but uploaded as workflow artifacts in CI.
-
-## Troubleshooting
-
-### Build Failures
-
-**Issue**: `npm run build` fails
-- Check Node.js version: `node --version` (must be 24+)
-- Clear node_modules: `rm -rf node_modules && npm ci`
-- Check TypeScript errors: `npm run typecheck`
-
-### Test Failures
-
-**Issue**: Action runs fail with API errors
-- Ensure `GEMINI_API_KEY` is set in `.env` when running the action against Gemini
-- Ensure `GITHUB_TOKEN` is set in `.env`
-- Check internet connectivity
-
-### dist Out of Sync
-
-**Issue**: CI fails with "Ensure dist is up to date"
-- Run `npm run build` locally
-- Commit the updated dist folder
-- Push changes
-
-## Best Practices
-
-1. **Always rebuild dist** after changing source code
-2. **Run type-check** before committing
-3. **Run tests** to catch regressions
-4. **Use `npm ci`** in CI/CD and for clean installs
-5. **Keep dist committed** - GitHub Actions needs it
-6. **Don't edit dist manually** - always regenerate with `npm run build`
-7. **Follow TypeScript strict mode** - project uses strict compiler options
-
-## Additional Resources
-
-- **README.md** - User-facing documentation and setup guide
-- **action.yml** - GitHub Action configuration and input definitions
-- **examples/** - Sample prompts and workflow configurations
-- **.github/workflows/** - CI/CD pipeline definitions
-
-## Questions?
-
-For questions or issues:
-1. Check existing issues on GitHub
-2. Review the README.md for user documentation
-3. Examine the CI workflows for expected behavior
-4. Consult TypeScript and GitHub Actions documentation
+Unit tests should not require real GitHub or Gemini credentials. Use mocks for API boundaries.

--- a/README.md
+++ b/README.md
@@ -9,20 +9,13 @@ AutoTriage is a GitHub Action for AI-assisted issue and pull request triage. It 
 3. Add a dry-run workflow:
 
 ```yaml
-name: nightly-auto-triage
+name: triage
 on:
   schedule:
     - cron: "0 0 * * *"
 jobs:
   triage:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
       - uses: actions/checkout@v6
       - name: AutoTriage
@@ -31,11 +24,15 @@ jobs:
           dry-run: "true" # change to "false" after reviewing the plan output
 ```
 
-4. Review the artifacts, then set `dry-run: "false"` when you are ready.
+For event-specific workflows, start from the examples in [`examples/workflows`](./examples/workflows/):
+
+- [`autotriage-issues.yml`](./examples/workflows/autotriage-issues.yml) - run on issue events.
+- [`autotriage-prs.yml`](./examples/workflows/autotriage-prs.yml) - run on pull request events.
+- [`autotriage-backlog.yml`](./examples/workflows/autotriage-backlog.yml) - scheduled backlog sweep.
 
 ## Inputs
 
-| Input | Purpose | Default |
+| Name | Purpose | Default |
 | --- | --- | --- |
 | `additional-instructions` | Extra prompt instructions for this run. | - |
 | `budget-scale` | Multiplier for prompt context limits. | `1` |
@@ -50,32 +47,9 @@ jobs:
 | `prompt-path` | Repo-relative path to the triage prompt. | `.github/AutoTriage.prompt` |
 | `strict-mode` | Fail the job when any item analysis fails. | `"false"` |
 
-Your repository's `README.md` is automatically included as extra Markdown context in the review pass when present.
+## Example
 
-## Environment
-
-AutoTriage reads credentials from environment variables:
-
-| Variable | Required | Purpose |
-| --- | --- | --- |
-| `GITHUB_TOKEN` | Yes | Reads issue/PR context and applies authorized GitHub changes. |
-| `GEMINI_API_KEY` | Yes | Calls the Gemini API for analysis. |
-
-## Example Workflows
-
-Workflow examples are available in [`examples/workflows`](./examples/workflows/):
-
-- [`autotriage-issues.yml`](./examples/workflows/autotriage-issues.yml) – run on issue events.
-- [`autotriage-prs.yml`](./examples/workflows/autotriage-prs.yml) – run on pull request events.
-- [`autotriage-backlog.yml`](./examples/workflows/autotriage-backlog.yml) – scheduled/backlog sweep.
-
-Backlog auto-discovery runs automatically try Gemini [context caching](https://ai.google.dev/gemini-api/docs/caching) and [flex inference](https://ai.google.dev/gemini-api/docs/flex-inference). If cache creation is unavailable for your account tier, AutoTriage falls back to normal uncached requests without failing the run.
-
-Copy one into `.github/workflows/` and adjust `dry-run`, schedules, inputs, and permissions for your repository.
-
-## Example Run
-
-[MudBlazor](https://github.com/MudBlazor/MudBlazor) is a popular UI library that uses AutoTriage for all new issues, PRs, and comments.
+[MudBlazor](https://github.com/MudBlazor/MudBlazor) uses AutoTriage for all new issues, PRs, and comments.
 
 Here's what a typical thought process looks like:
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,12 @@
 # AutoTriage
 
-Keep issues and pull requests moving: reads the latest context, drafts the next move, and applies it with the rules you define in your prompt.
-
-## How it works
-
-- The run starts with a fast AI pass to gather signals, summarize the thread, and draft the intended operations.
-- A reviewing AI pass (default: `gemini-3.1-pro-preview`) replays the plan and confirms labels, comments, etc, before anything is written.
-- Defaults use the free-tier models (`gemini-3.1-flash-lite` + `gemini-3.1-pro-preview`) rather than `gemini-3-pro`.
-- The full thought process along with all actions can be inspected in the workflow artifacts.
-- It will keep going until it runs out of issues or tokens, or reaches the specified limit.
+AutoTriage is a GitHub Action for AI-assisted issue and pull request triage. It reads repository context, issue or pull request history, and a repository-defined prompt, then plans and applies authorized GitHub operations.
 
 ## Quick setup
 
-1. Copy the [default prompt](./examples/AutoTriage.prompt) into your repo as `.github/AutoTriage.prompt` and tailor the labeling rules or tone.
-2. Add a `GEMINI_API_KEY` secret to your repository (or organization) pointing at your AI provider key.
-3. Drop a dry-run workflow such as:
+1. Copy the [default prompt](./examples/AutoTriage.prompt) into your repo as `.github/AutoTriage.prompt` and define your triage rules.
+2. Add a `GEMINI_API_KEY` secret to your repository or organization.
+3. Add a dry-run workflow:
 
 ```yaml
 name: nightly-auto-triage
@@ -24,38 +16,54 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
       - uses: actions/checkout@v6
       - name: AutoTriage
         uses: danielchalmers/AutoTriage@v3
         with:
-          dry-run: true # flip to false once you're comfortable with the plan output
+          dry-run: "true" # change to "false" after reviewing the plan output
 ```
 
-4. Review the artifacts, then set `dry-run: false` when you are ready.
+4. Review the artifacts, then set `dry-run: "false"` when you are ready.
 
 ## Inputs
 
 | Input | Purpose | Default |
 | --- | --- | --- |
-| `additional-instructions` | Additional instructions appended to the prompt for testing or tweaking behavior without committing a new prompt. | - |
-| `budget-scale` | Scales all internal Fast/Pro context limits (`1` = defaults, `2` ≈ double). | `1` |
-| `db-path` | Persist per-item history between runs. | - |
-| `dry-run` | `"true"` logs the plan only, `"false"` applies changes. | `"false"` |
-| `extended` | When `"true"`, include unchanged issues and recently closed issues in auto-discovery. | `"false"` |
-| `issues` | Explicit issue/PR list (space or comma separated); falls back to the GitHub event target when omitted. Explicit targets stay uncached. | event target |
-| `max-fast-runs` | Cap on items analyzed with the fast model per run. | `100` |
-| `max-pro-runs` | Cap on items that escalate to the review pass per run. | `20` |
-| `model-fast` | Fast analysis model for the first pass. Leave blank to skip. | `gemini-3.1-flash-lite` |
-| `model-pro` | Review model that double-checks uncertain plans. | `gemini-3.1-pro-preview` |
-| `prompt-path` | Path to the triage prompt file you control. | `.github/AutoTriage.prompt` |
-| `strict-mode` | Fail the overall job if any individual run errors occur. | `"false"` |
+| `additional-instructions` | Extra prompt instructions for this run. | - |
+| `budget-scale` | Multiplier for prompt context limits. | `1` |
+| `db-path` | Path to the triage history JSON file. | - |
+| `dry-run` | Log planned actions without applying changes. | `"false"` |
+| `extended` | Broaden backlog auto-discovery. | `"false"` |
+| `issues` | Space or comma separated issue or PR numbers. | event target or backlog |
+| `max-fast-runs` | Maximum fast-model analyses per run. | `100` |
+| `max-pro-runs` | Maximum review-model analyses per run. | `20` |
+| `model-fast` | Fast-pass model. Leave blank to skip. | `gemini-3.1-flash-lite` |
+| `model-pro` | Review model for final planning. | `gemini-3.1-pro-preview` |
+| `prompt-path` | Repo-relative path to the triage prompt. | `.github/AutoTriage.prompt` |
+| `strict-mode` | Fail the job when any item analysis fails. | `"false"` |
 
-Your repository's `README.md` is automatically included as extra Markdown context when present.
+Your repository's `README.md` is automatically included as extra Markdown context in the review pass when present.
+
+## Environment
+
+AutoTriage reads credentials from environment variables:
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | Yes | Reads issue/PR context and applies authorized GitHub changes. |
+| `GEMINI_API_KEY` | Yes | Calls the Gemini API for analysis. |
 
 ## Example Workflows
 
-See ready-to-use workflow files in [`examples/workflows`](./examples/workflows/):
+Workflow examples are available in [`examples/workflows`](./examples/workflows/):
 
 - [`autotriage-issues.yml`](./examples/workflows/autotriage-issues.yml) – run on issue events.
 - [`autotriage-prs.yml`](./examples/workflows/autotriage-prs.yml) – run on pull request events.
@@ -63,9 +71,9 @@ See ready-to-use workflow files in [`examples/workflows`](./examples/workflows/)
 
 Backlog auto-discovery runs automatically try Gemini [context caching](https://ai.google.dev/gemini-api/docs/caching) and [flex inference](https://ai.google.dev/gemini-api/docs/flex-inference). If cache creation is unavailable for your account tier, AutoTriage falls back to normal uncached requests without failing the run.
 
-Copy one into `.github/workflows/` and adjust `dry-run`, schedules, or permissions as needed.
+Copy one into `.github/workflows/` and adjust `dry-run`, schedules, inputs, and permissions for your repository.
 
-## Example
+## Example Run
 
 [MudBlazor](https://github.com/MudBlazor/MudBlazor) is a popular UI library that uses AutoTriage for all new issues, PRs, and comments.
 

--- a/action.yml
+++ b/action.yml
@@ -1,54 +1,54 @@
 name: "AutoTriage"
-description: "AI issue & PR triage that reads context, drafts a plan, and applies it according to your project prompt."
+description: "GitHub Action for AI-assisted issue and pull request triage using a repository-defined prompt."
 author: "Daniel Chalmers"
 branding:
   color: "blue"
-  icon: "robot"
+  icon: "git-pull-request"
 
 inputs:
   additional-instructions:
-    description: "Additional instructions appended to the prompt for testing or tweaking behavior without committing a new prompt."
+    description: "Extra prompt instructions for this run."
     required: false
   budget-scale:
-    description: "Scalar multiplier for internal Fast/Pro context limits. Use values >1 to allow more prompt context."
+    description: "Multiplier for prompt context limits."
     required: false
     default: "1"
   db-path:
-    description: "Optional path to a JSON file that stores per-item history between runs."
+    description: "Path to the triage history JSON file."
     required: false
   dry-run:
-    description: "Set to true to log the plan only; false applies labels, comments, and title changes."
+    description: "Log planned actions without applying changes."
     required: false
     default: "false"
   extended:
-    description: "Set to true to include unchanged issues and recently closed issues during backlog auto-discovery."
+    description: "Broaden backlog auto-discovery."
     required: false
     default: "false"
   issues:
-    description: "Space or comma separated list of issue / PR numbers to triage explicitly; when omitted the GitHub event target is used."
+    description: "Space or comma separated issue or PR numbers."
     required: false
   max-fast-runs:
-    description: "Cap on how many targets can be analyzed with the fast model during this run."
+    description: "Maximum fast-model analyses per run."
     required: false
     default: "100"
   max-pro-runs:
-    description: "Cap on how many targets can escalate to the review pass during this run."
+    description: "Maximum review-model analyses per run."
     required: false
     default: "20"
   model-fast:
-    description: "Identifier of the fast analysis model used for the first pass (default shown below). Leave blank to skip the fast pass."
+    description: "Fast-pass model. Leave blank to skip."
     required: false
     default: "gemini-3.1-flash-lite"
   model-pro:
-    description: "Identifier of the deeper review model used when the fast pass asks for confirmation."
+    description: "Review model for final planning."
     required: false
     default: "gemini-3.1-pro-preview"
   prompt-path:
-    description: "Repo-relative path to the prompt template that governs triage behavior (tone, rules, closure policy)."
+    description: "Repo-relative path to the triage prompt."
     required: false
     default: ".github/AutoTriage.prompt"
   strict-mode:
-    description: "Set to true to fail the overall job if any runs have errors."
+    description: "Fail the job when any item analysis fails."
     required: false
     default: "false"
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autotriage",
   "version": "0.1.0",
-  "description": "AI triage for GitHub issues & PRs: reads context, drafts the next move, and applies it with your project prompt.",
+  "description": "GitHub Action for AI-assisted issue and pull request triage using a repository-defined prompt.",
   "main": "dist/index.js",
   "type": "commonjs",
   "scripts": {
@@ -16,10 +16,10 @@
   },
   "keywords": [
     "github-actions",
-    "triage",
-    "issues",
-    "pull-requests",
-    "ai"
+    "issue-triage",
+    "pull-request-triage",
+    "github-automation",
+    "ai-triage"
   ],
   "author": "Daniel Chalmers",
   "license": "MIT",


### PR DESCRIPTION
Updates the repository guidance and public documentation to be more maintainable and more aligned with the action’s current contract.

Notes

- Keeps agent guidance focused on project-specific rules instead of general onboarding.
- Adds explicit expectations around test quality, especially avoiding weak or duplicate tests.
- Reworks public-facing copy to be more direct and developer-oriented.
- Keeps detailed behavior out of overloaded input descriptions while preserving the useful setup and reference material.