### PR TITLE
Update workflow examples for v4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: AutoTriage
-        uses: danielchalmers/AutoTriage@v3
+        uses: danielchalmers/AutoTriage@v4
         with:
           dry-run: "true" # change to "false" after reviewing the plan output
 ```

--- a/examples/workflows/autotriage-backlog.yml
+++ b/examples/workflows/autotriage-backlog.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: triage-db-
 
       - name: AutoTriage - triage backlog
-        uses: danielchalmers/AutoTriage@v3
+        uses: danielchalmers/AutoTriage@v4
         with:
           issues: ${{ github.event.inputs.issues }}
           prompt-path: .github/AutoTriage.prompt

--- a/examples/workflows/autotriage-comments.yml
+++ b/examples/workflows/autotriage-comments.yml
@@ -27,7 +27,7 @@ jobs:
           restore-keys: triage-db-
 
       - name: AutoTriage - triage comment
-        uses: danielchalmers/AutoTriage@v3
+        uses: danielchalmers/AutoTriage@v4
         with:
           issues: ${{ github.event.issue.number }}
           prompt-path: .github/AutoTriage.prompt

--- a/examples/workflows/autotriage-issues.yml
+++ b/examples/workflows/autotriage-issues.yml
@@ -27,7 +27,7 @@ jobs:
           restore-keys: triage-db-
 
       - name: AutoTriage - triage issue
-        uses: danielchalmers/AutoTriage@v3
+        uses: danielchalmers/AutoTriage@v4
         with:
           issues: ${{ github.event.issue.number }}
           prompt-path: .github/AutoTriage.prompt

--- a/examples/workflows/autotriage-prs.yml
+++ b/examples/workflows/autotriage-prs.yml
@@ -27,7 +27,7 @@ jobs:
           restore-keys: triage-db-
 
       - name: AutoTriage - triage PR
-        uses: danielchalmers/AutoTriage@v3
+        uses: danielchalmers/AutoTriage@v4
         with:
           issues: ${{ github.event.pull_request.number }}
           prompt-path: .github/AutoTriage.prompt


### PR DESCRIPTION
## Summary
- Update the README quick-start workflow to reference `danielchalmers/AutoTriage@v4`.
- Update all example workflows from `@v3` to `@v4`.

## Validation
- `rg -n "@v3" README.md examples .github action.yml package.json src tests` returns no matches.
- Docs/examples only; no build output changes required.