### PR TITLE
Refine AGENTS.md into an agent harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,261 +1,193 @@
 # AGENTS.md
 
-This document provides comprehensive instructions for AI agents and developers working on the AutoTriage project. It outlines the setup process, development workflow, testing procedures, and build requirements.
+This file is the single-file agent harness for AutoTriage. It is intentionally
+short enough to stay useful in context while still giving agents the map,
+constraints, and feedback loops needed to make reliable changes.
 
-## Project Overview
+The design follows OpenAI's harness engineering guidance: agent effectiveness
+comes from repository-local knowledge, legible systems, enforceable invariants,
+and tight validation loops rather than a large instruction manual. Keep this
+file as the table of contents and operating contract for now; promote repeated
+rules into scripts, tests, or CI when they become stable.
 
-AutoTriage is a GitHub Action that uses AI to automatically triage issues and pull requests. It's built with TypeScript and requires Node.js 24+ for development, and runs on Node.js 24 in GitHub Actions.
+Source: https://openai.com/index/harness-engineering/
 
-## Prerequisites
+## Project Contract
 
-- **Node.js**: Version 24 or higher (specified in `package.json` engines)
-- **npm**: Comes bundled with Node.js
-- **Git**: For version control
-- **GitHub Token**: Required for testing (set as `GITHUB_TOKEN` environment variable)
-- **Gemini API Key**: Required for AI functionality when running the action locally (set as `GEMINI_API_KEY` environment variable)
+AutoTriage is a GitHub Action for AI-assisted issue and pull request triage. It
+uses repository context, issue or pull request history, and a configurable prompt
+to plan and apply authorized GitHub operations.
 
-## Repository Structure
+Preserve these invariants:
 
-```
-AutoTriage/
-├── .github/          # GitHub workflows and configuration
-├── dist/             # Compiled output (generated, committed to repo)
-├── examples/         # Example prompts and workflows
-├── src/              # TypeScript source code
-├── tests/            # Test files using Vitest
-├── action.yml        # GitHub Action metadata
-├── package.json      # Dependencies and scripts
-├── tsconfig.json     # TypeScript configuration
-└── vitest.config.ts  # Test configuration
-```
+- Runtime compatibility: Node.js 24 or newer.
+- Action entry point: `dist/index.js`.
+- Source of truth: TypeScript under `src/`.
+- Generated bundle: `dist/` is committed, but never edited manually.
+- Default prompt asset: `examples/AutoTriage.prompt` is copied to
+  `dist/AutoTriage.prompt` during build.
+- Unit tests must not require real GitHub or Gemini credentials.
+- Public action behavior must stay aligned across `action.yml`, `README.md`,
+  tests, and generated `dist/`.
 
-## Initial Setup
+## Context Map
 
-### 1. Clone the Repository
+Start with the smallest useful context:
 
-```bash
-git clone https://github.com/danielchalmers/AutoTriage.git
-cd AutoTriage
-```
+- `src/index.ts` - action entry point.
+- `src/config.ts` and `src/env.ts` - action inputs and environment handling.
+- `src/runner.ts` and `src/issueProcessor.ts` - orchestration and per-item work.
+- `src/github.ts` - GitHub API boundary.
+- `src/gemini.ts`, `src/analysis.ts`, `src/triage.ts` - model analysis and
+  operation planning.
+- `src/prompts.ts` and `src/prompt.ts` - prompt loading and prompt assembly.
+- `src/storage.ts` and `src/stats.ts` - persisted triage data and run metrics.
+- `tests/` - Vitest coverage and examples of expected behavior.
+- `action.yml` - public GitHub Action metadata.
+- `examples/AutoTriage.prompt` - bundled fallback prompt.
+- `.github/workflows/` - CI expectations.
+- `dist/` - generated action bundle.
 
-### 2. Install Dependencies
+Read the relevant source and nearby tests before editing. Prefer
+repository-local evidence over assumptions from memory.
 
-```bash
-npm ci
-```
+## Operating Loop
 
-Use `npm ci` (clean install) for reproducible builds based on `package-lock.json`.
+For any change:
 
-### 3. Set Up Environment Variables
+1. Inspect the current implementation, tests, and public contract.
+2. Make the smallest coherent change.
+3. Add or update focused tests when behavior changes.
+4. Run the narrowest useful verification first.
+5. Run required verification before finishing.
+6. Rebuild `dist/` when source, bundled assets, dependencies, or action metadata
+   affect runtime output.
+7. Summarize what changed, what was verified, and any remaining risk.
 
-Create a `.env` file in the root directory (this file is gitignored):
+If something fails, do not guess. Treat the failure as a missing capability,
+broken invariant, stale test, or real regression. Fix the specific cause.
 
-```bash
-GITHUB_TOKEN=your_github_token_here
-GEMINI_API_KEY=your_gemini_api_key_here
-```
+## Required Verification
 
-These are required for local development when exercising the action against GitHub and Gemini. Unit tests do not require `GEMINI_API_KEY`.
-
-## Development Workflow
-
-### Available npm Scripts
-
-- `npm run typecheck` - Type-check TypeScript without emitting files
-- `npm run dev` - Watch mode for TypeScript compilation
-- `npm run build` - Full production build (includes typecheck, clean, compile, and asset copy)
-- `npm run clean` - Remove the dist directory
-- `npm run copy-assets` - Copy required assets to dist folder
-- `npm test` - Run all tests once
-- `npm run test:watch` - Run tests in watch mode
-
-### TypeScript Development
-
-1. Make changes to source files in `src/`
-2. Run type checking: `npm run typecheck`
-3. For continuous development, use watch mode: `npm run dev`
-
-### Testing
-
-Tests are located in the `tests/` directory and use Vitest.
-
-#### Running Tests
+Default verification:
 
 ```bash
-# Run all tests once
+npm run typecheck
+npm run typecheck:test
 npm test
-
-# Run tests in watch mode (for development)
-npm run test:watch
 ```
 
-#### Test Environment
-
-- Tests use Vitest with Node.js environment
-- Setup file: `tests/setupEnv.ts`
-- Test files: `tests/**/*.test.ts`
-
-## Building the Project
-
-### Creating the dist Folder
-
-The `dist/` folder contains the compiled, bundled JavaScript that GitHub Actions executes. **This folder must be committed to the repository** as GitHub Actions runs directly from it.
-
-#### Build Process
+When runtime output may change, also run:
 
 ```bash
 npm run build
-```
-
-This command performs the following steps:
-
-1. **Type-checking** (`npm run typecheck`) - Validates TypeScript code
-2. **Clean** (`rimraf dist`) - Removes existing dist folder
-3. **Bundle** (`ncc build`) - Compiles and bundles TypeScript to a single JavaScript file
-   - Minifies the output
-   - Generates source maps
-   - Includes license information in `licenses.txt`
-4. **Copy Assets** (`npm run copy-assets`) - Copies `examples/AutoTriage.prompt` to dist as the bundled default prompt
-
-#### Important: Commit dist Changes
-
-After building, the `dist/` folder contents must be committed:
-
-```bash
-npm run build
-git add dist/
-git commit -m "Build: Update dist folder"
-```
-
-The CI workflow (`ci.yml`) verifies that the dist folder is up to date:
-
-```bash
 git status --porcelain
 git diff --exit-code --name-only
 ```
 
-If you forget to rebuild dist after changing source code, the CI will fail.
+Docs-only changes usually do not require `npm run build`. Changes to `src/`,
+`examples/AutoTriage.prompt`, `package.json`, `package-lock.json`,
+`action.yml`, or bundling behavior require build verification and updated
+`dist/` output when the bundle changes.
 
-## Pre-commit Checklist
+## Development Commands
 
-Before committing changes, ensure:
+- `npm ci` - install dependencies from `package-lock.json`.
+- `npm run typecheck` - type-check runtime TypeScript.
+- `npm run typecheck:test` - type-check tests.
+- `npm test` - run Vitest once.
+- `npm run test:watch` - run Vitest in watch mode.
+- `npm run dev` - run TypeScript in watch mode.
+- `npm run build` - type-check, clean `dist/`, bundle with `ncc`, and copy the
+  fallback prompt asset.
+- `npm run clean` - remove `dist/`.
+- `npm run copy-assets` - copy `examples/AutoTriage.prompt` into `dist/`.
 
-1. ✅ **Type-check passes**: `npm run typecheck`
-2. ✅ **Tests pass**: `npm test`
-3. ✅ **Build succeeds**: `npm run build`
-4. ✅ **dist is up to date**: Commit any changes in `dist/` folder
-5. ✅ **No uncommitted changes in dist**: `git status` shows clean dist
+## Change Rules
 
-## Continuous Integration
+### Source Changes
 
-The project uses GitHub Actions for CI (`.github/workflows/ci.yml`):
+- Keep TypeScript strictness intact.
+- Validate or narrow untrusted shapes at boundaries, especially GitHub event
+  payloads, action inputs, API responses, stored JSON, and model output.
+- Keep external service access isolated behind modules that tests can mock.
+- Avoid broad refactors unless they directly reduce risk for the requested
+  change.
 
-1. Installs dependencies with `npm ci`
-2. Runs type-checking
-3. Builds the project
-4. Verifies dist folder is up to date
-5. Runs a mock triage test
-6. Runs unit tests (separate workflow: `tests.yml`)
+### Public Action Changes
 
-## Common Tasks
+When changing inputs, defaults, permissions, or runtime behavior:
 
-### Adding New Dependencies
+- Update `action.yml`.
+- Update `README.md` when user-facing behavior changes.
+- Add or update tests for parsing, defaults, and failure behavior.
+- Run `npm run build` and inspect generated `dist/` changes.
 
-```bash
-# Add production dependency
-npm install <package-name>
+### Prompt Changes
 
-# Add development dependency
-npm install -D <package-name>
+When changing prompt loading or prompt assets:
 
-# Rebuild after adding dependencies
-npm run build
-```
+- Test custom prompt path behavior.
+- Test bundled fallback behavior.
+- Test missing or invalid prompt behavior when applicable.
+- Rebuild so `dist/AutoTriage.prompt` matches the source asset.
 
-### Updating TypeScript Code
+### Dependency Changes
 
-1. Edit source files in `src/`
-2. Run `npm run typecheck` to verify types
-3. Run `npm test` to ensure tests pass
-4. Run `npm run build` to update dist
-5. Commit both source and dist changes
+Before adding a dependency, check whether the existing stack already solves the
+problem. New dependencies must be compatible with Node.js 24 and GitHub Actions,
+committed in `package-lock.json`, covered by relevant tests, and included in the
+rebuilt bundle when used at runtime.
 
-### Debugging
+## Testing Expectations
 
-For debugging the action locally:
+For triage behavior, cover:
 
-1. Set up `.env` file with required tokens
-2. Use the mock triage setup from CI:
-   ```bash
-   # Build first
-   npm run build
-   
-   # Then test locally (requires proper GitHub Action environment)
-   ```
+- Normal issue or pull request processing.
+- Missing, malformed, or partial inputs.
+- Model or GitHub API failure paths.
+- Dry-run behavior.
+- Storage, artifact, or stats changes when touched.
 
-### Working with the GitHub Action
+For GitHub integration boundaries, prefer mocked clients and representative
+payload fixtures over live network calls. Local development against real GitHub
+or Gemini requires `GITHUB_TOKEN` and `GEMINI_API_KEY`, but unit tests should not
+depend on either.
 
-The action is defined in `action.yml` and runs from `dist/index.js`. Key points:
+## Failure Recovery
 
-- **Entry point**: `dist/index.js`
-- **Runtime**: Node.js 24 (specified in `action.yml`)
-- **Inputs**: Defined in `action.yml`
-- **Default prompt path**: `.github/AutoTriage.prompt` (where users place their custom prompt)
-- **Bundled prompt**: `examples/AutoTriage.prompt` (copied to dist during build as fallback)
+- `npm ci` fails: check Node/npm version and lockfile consistency.
+- Typecheck fails: fix types rather than weakening strictness.
+- Tests fail: determine whether the failure is a regression, stale expectation,
+  missing mock, or environment issue.
+- Build fails: inspect the first compiler or bundler error before retrying.
+- `dist/` changes unexpectedly: inspect the generated diff before finishing.
+- Credentials are missing: do not invent them; report the blocked verification.
 
-## File Artifacts
+## Pull Request Readiness
 
-The action generates artifacts during execution:
+Before opening or updating a PR:
 
-- `triage-db.json` - Stores per-item history between runs
-- `artifacts/` - Contains thought processes and action logs
+- Verification has passed, or blocked checks are named with reasons.
+- Runtime-impacting changes have rebuilt `dist/`.
+- Public behavior changes are reflected in docs and tests.
+- Unrelated files are not modified.
+- The PR body explains the why, the what, verification, and residual risk.
 
-These are gitignored but uploaded as workflow artifacts in CI.
+## Harness Improvement Backlog
 
-## Troubleshooting
+These are good follow-up investments because OpenAI's harness engineering post
+argues that durable agent leverage comes from legible repository systems,
+mechanical checks, and feedback loops rather than repeated manual guidance.
 
-### Build Failures
-
-**Issue**: `npm run build` fails
-- Check Node.js version: `node --version` (must be 24+)
-- Clear node_modules: `rm -rf node_modules && npm ci`
-- Check TypeScript errors: `npm run typecheck`
-
-### Test Failures
-
-**Issue**: Action runs fail with API errors
-- Ensure `GEMINI_API_KEY` is set in `.env` when running the action against Gemini
-- Ensure `GITHUB_TOKEN` is set in `.env`
-- Check internet connectivity
-
-### dist Out of Sync
-
-**Issue**: CI fails with "Ensure dist is up to date"
-- Run `npm run build` locally
-- Commit the updated dist folder
-- Push changes
-
-## Best Practices
-
-1. **Always rebuild dist** after changing source code
-2. **Run type-check** before committing
-3. **Run tests** to catch regressions
-4. **Use `npm ci`** in CI/CD and for clean installs
-5. **Keep dist committed** - GitHub Actions needs it
-6. **Don't edit dist manually** - always regenerate with `npm run build`
-7. **Follow TypeScript strict mode** - project uses strict compiler options
-
-## Additional Resources
-
-- **README.md** - User-facing documentation and setup guide
-- **action.yml** - GitHub Action configuration and input definitions
-- **examples/** - Sample prompts and workflow configurations
-- **.github/workflows/** - CI/CD pipeline definitions
-
-## Questions?
-
-For questions or issues:
-1. Check existing issues on GitHub
-2. Review the README.md for user documentation
-3. Examine the CI workflows for expected behavior
-4. Consult TypeScript and GitHub Actions documentation
+- Add `npm run verify` to run typecheck, test typecheck, tests, build, and the
+  `dist/` freshness check in one command.
+- Add a focused `npm run check:dist` script so local and CI checks share the
+  same generated-output invariant.
+- Add representative GitHub issue, pull request, and comment fixtures for
+  behavior tests.
+- Add model-response fixtures for Gemini planning edge cases.
+- Add structural tests for action input metadata and README input documentation
+  alignment.
+- Add a periodic documentation freshness check once the project has more
+  repository-local design notes.


### PR DESCRIPTION
## Proposal

This PR reshapes `AGENTS.md` from a broad setup guide into a single-file agent harness for AutoTriage.

It keeps the project at one agent-facing file for now, but changes the file's job:

- from "comprehensive manual" to "operating contract and context map"
- from repeated setup prose to enforceable project invariants
- from generic best practices to concrete feedback loops agents can run locally
- from implicit tribal knowledge to explicit rules for source, prompts, public action metadata, tests, and generated `dist/`

The proposal is intentionally conservative. It does not introduce a new docs tree, new scripts, or new CI requirements yet. The only implementation change is `AGENTS.md`.

## Why

OpenAI's harness engineering write-up argues that agent effectiveness improves when the repository itself becomes the system of record, and when agents get a map, not a giant manual: https://openai.com/index/harness-engineering/

That maps directly to AutoTriage:

- AutoTriage already has a small, legible structure: `src/`, `tests/`, `examples/`, `action.yml`, workflows, and committed `dist/`.
- The current `AGENTS.md` contains useful facts, but it reads mostly like human onboarding documentation.
- The highest-risk recurring agent mistakes in this repo are not setup mistakes; they are harness mistakes: forgetting `dist`, touching generated files manually, changing action inputs without docs/tests, requiring live credentials in tests, or guessing at GitHub/model data shapes.

The updated file makes those risks first-class.

## What changed

The new `AGENTS.md` now has these sections:

- `Project Contract`: stable invariants agents must preserve.
- `Context Map`: where to look first for each kind of change.
- `Operating Loop`: inspect, change, test, rebuild when needed, summarize risk.
- `Required Verification`: default commands and when to run the build/dist freshness checks.
- `Development Commands`: concise command reference.
- `Change Rules`: specific rules for source, public action, prompt, and dependency changes.
- `Testing Expectations`: what behavior needs tests when triage logic, integrations, prompts, or storage are touched.
- `Failure Recovery`: how agents should reason about common failures instead of retrying blindly.
- `Pull Request Readiness`: the final checklist before opening or updating a PR.
- `Harness Improvement Backlog`: sourced follow-up work for turning repeated guidance into scripts, tests, and checks.

It also removes mojibake from the previous tree/checkmark glyphs by keeping the file ASCII-only.

## Source-backed reasoning

The OpenAI post makes four points that guided this implementation:

1. Keep the entry point small.

   The post says large monolithic instruction files crowd out relevant task context, rot quickly, and are hard to verify. The updated file is shorter and structured as a map plus operating contract rather than a full handbook.

2. Put knowledge where agents can access it.

   The post frames repository-local knowledge as the system of record. The updated `Context Map` points agents to local source, tests, workflows, prompt assets, and action metadata instead of relying on memory or external explanation.

3. Prefer mechanical feedback loops.

   The post emphasizes validation loops, legibility, and enforceable checks. The updated `Required Verification`, `Failure Recovery`, and `Pull Request Readiness` sections make those loops explicit for this repo.

4. Encode judgment into durable harnesses.

   The post argues that repeated human taste and review feedback should become documentation, tooling, or checks. The backlog captures follow-up work such as `npm run verify`, `check:dist`, fixtures, and structural docs/action metadata tests.

Source: https://openai.com/index/harness-engineering/

## Why keep it as one file

AutoTriage is still small enough that splitting agent instructions across multiple docs would add navigation overhead before it adds leverage.

The single-file approach is useful right now because:

- the repo has a compact architecture
- the public contract is concentrated in `action.yml`, `README.md`, and `dist/`
- the most important guidance fits in one readable file
- follow-up harness work should first prove itself as scripts/tests before becoming a larger docs system

The file still leaves an upgrade path: if this grows, `AGENTS.md` can remain the table of contents while deeper design notes move into versioned docs.

## Follow-up work

These are not included in this PR because the requested change is the proposal and single-file implementation. They are listed in `AGENTS.md` as future harness improvements.

- Add `npm run verify`.

  Reasoning: one canonical command lowers the chance that agents run only part of the required loop. This follows the harness-engineering emphasis on feedback loops and mechanical validation.

- Add `npm run check:dist`.

  Reasoning: CI already checks generated output freshness. Sharing that invariant through a local script would make the rule easier for agents and humans to run before opening a PR.

- Add representative GitHub issue, PR, and comment fixtures.

  Reasoning: the source article emphasizes application legibility. For AutoTriage, representative payload fixtures make GitHub event behavior legible without live credentials.

- Add Gemini response fixtures for planning edge cases.

  Reasoning: model-output handling is one of this action's most important boundaries. Fixtures make failure modes repeatable and reviewable.

- Add structural tests for action input metadata and README alignment.

  Reasoning: public action behavior spans `action.yml`, docs, tests, and generated output. A structural check would encode that review expectation as a durable harness.

Source for the harness direction: https://openai.com/index/harness-engineering/

## Verification

- `npm run typecheck`
- `npm run typecheck:test`
- `npm test`

`npm test` initially failed inside the sandbox with Windows `spawn EPERM` while Vitest loaded config. It passed after rerunning with normal process-spawn permissions:

- 13 test files passed
- 98 tests passed

No build was run because this is a docs-only change and does not affect runtime output or `dist/`.

## Risk

Low. This changes only agent/developer guidance. Runtime code, action metadata, tests, package files, and generated bundle output are unchanged.
