### PR TITLE
Add verification and dist freshness scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Ensure dist is up to date
-        run: |
-          git status --porcelain
-          git diff --exit-code --name-only
+        run: npm run check:dist
       - name: Mock triage
         if: github.event_name == 'pull_request'
         uses: ./

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "type": "commonjs",
   "scripts": {
     "build": "npm run typecheck && npm run clean && ncc build src/index.ts -o dist --minify --source-map --license licenses.txt && npm run copy-assets",
+    "check:dist": "node scripts/check-dist.cjs",
     "copy-assets": "node -e \"require('fs').cpSync('examples/AutoTriage.prompt', 'dist/AutoTriage.prompt')\"",
     "clean": "node -e \"require('fs').rmSync('dist', {recursive:true, force:true})\"",
     "typecheck": "tsc --noEmit",
     "typecheck:test": "tsc -p tsconfig.test.json",
     "dev": "tsc -w",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "verify": "npm run typecheck && npm run typecheck:test && npm test && npm run build && npm run check:dist"
   },
   "keywords": [
     "github-actions",

--- a/scripts/check-dist.cjs
+++ b/scripts/check-dist.cjs
@@ -1,0 +1,13 @@
+const { execFileSync } = require("node:child_process");
+
+const status = execFileSync("git", ["status", "--porcelain", "--", "dist"], {
+  encoding: "utf8",
+});
+
+if (status.trim().length > 0) {
+  console.error("dist is not up to date. Run npm run build and commit the generated output.");
+  console.error(status.trimEnd());
+  process.exit(1);
+}
+
+console.log("dist is up to date.");


### PR DESCRIPTION
## Proposal

This PR implements the first two harness follow-ups from #139:

- add `npm run verify`
- add `npm run check:dist`

The goal is to turn repeated review guidance into repository-local commands that both humans and agents can run without reconstructing the expected sequence from prose.

## Why

#139 reframed `AGENTS.md` as a single-file operating harness. This PR makes two of its mechanical feedback loops executable.

OpenAI's harness engineering write-up argues that agent reliability improves when repositories provide legible systems, tight validation loops, and mechanical checks rather than relying on repeated manual guidance: https://openai.com/index/harness-engineering/

That applies directly here:

- AutoTriage is a committed-`dist` GitHub Action, so source correctness is not enough.
- The runtime contract depends on generated output staying current.
- Agents are most likely to make mistakes when verification is split across several remembered commands.
- A single command gives future agents and maintainers a stable local target before opening a PR.

## What changed

### Added `npm run verify`

`verify` now runs the full expected local loop:

```bash
npm run typecheck && npm run typecheck:test && npm test && npm run build && npm run check:dist
```

This intentionally includes build verification because `dist/` is part of the shipped action. A PR can pass source tests while still being wrong for GitHub Actions if the bundle is stale.

### Added `npm run check:dist`

`check:dist` runs `scripts/check-dist.cjs`, which checks for dirty or untracked files under `dist/`:

```bash
git status --porcelain -- dist
```

If `dist/` is dirty, the script prints the changed paths and exits non-zero with the remediation:

```text
dist is not up to date. Run npm run build and commit the generated output.
```

This keeps the generated-output invariant available outside CI.

### Updated CI to use the shared command

The CI job now calls:

```bash
npm run check:dist
```

instead of embedding raw git commands in the workflow. This keeps local and CI behavior aligned.

## Design choices

### Use a script file instead of inline package JSON

The dist check could have been written as a long `node -e` command in `package.json`. A small script is easier to read, easier to change, and gives a clearer failure message. That is consistent with the harness-engineering idea that the repository should expose legible tools rather than making agents infer behavior from shell fragments.

### Scope `check:dist` to `dist/`

The old CI step checked the whole worktree after build. The actual invariant being enforced is generated action output freshness, so this command scopes the check to `dist/`.

That is more precise:

- docs-only or tooling-only working tree changes do not matter to the generated bundle check
- source changes that alter runtime output still fail after build
- untracked generated files under `dist/` are still caught

### Keep `verify` explicit

The command repeats `typecheck` because `npm run build` already runs it. That small duplication is intentional. `verify` is meant to be the obvious full local acceptance command, not the shortest possible shell expression.

## Relationship to #139

#139 provides the proposal and documentation-level rationale for treating AutoTriage's agent instructions as a harness. This PR implements the first concrete mechanical harness from that proposal.

Reference: #139

Source: https://openai.com/index/harness-engineering/

## Verification

Passed locally:

```bash
npm run typecheck
npm run typecheck:test
npm test
npm run check:dist
```

`npm test` and `npm run check:dist` needed normal process-spawn permissions on this Windows machine because the sandbox blocked child process creation with `EPERM`.

I also exercised `npm run verify`. It reached the build/dist phase and surfaced an existing Windows `ncc` generated-output difference in `dist/index.js` around artifact path handling. I did not include that generated diff because it is unrelated to this PR and would change runtime artifact behavior. CI's Ubuntu build remains the merge authority for the full `verify` sequence.

## Risk

Low for runtime behavior. The action source and bundled runtime are unchanged.

The main behavioral change is in developer and CI ergonomics: CI now calls the same dist freshness command that local users and agents can run.
